### PR TITLE
Fix profile percentage

### DIFF
--- a/core/interfaces/src/main/java/info/nightscout/interfaces/profile/Profile.kt
+++ b/core/interfaces/src/main/java/info/nightscout/interfaces/profile/Profile.kt
@@ -112,6 +112,7 @@ interface Profile {
     fun getMaxDailyBasal(): Double
     fun baseBasalSum(): Double
     fun percentageBasalSum(): Double
+    fun getOriginalPercentage(): Int
 
     fun getBasalValues(): Array<ProfileValue>
     fun getIcsValues(): Array<ProfileValue>

--- a/core/main/src/main/java/info/nightscout/core/profile/ProfileSealed.kt
+++ b/core/main/src/main/java/info/nightscout/core/profile/ProfileSealed.kt
@@ -347,6 +347,11 @@ sealed class ProfileSealed(
         return result
     }
 
+    override fun getOriginalPercentage(): Int {
+        if (this is EPS) return value.originalPercentage
+        return pct
+    }
+
     override fun getBasalValues(): Array<ProfileValue> = getValues(basalBlocks, percentage / 100.0)
     override fun getIcsValues(): Array<ProfileValue> = getValues(icBlocks, 100.0 / percentage)
 

--- a/plugins/aps/src/main/java/info/nightscout/plugins/aps/tsunami/DetermineBasalAdapterTsunamiJS.kt
+++ b/plugins/aps/src/main/java/info/nightscout/plugins/aps/tsunami/DetermineBasalAdapterTsunamiJS.kt
@@ -332,7 +332,7 @@ class DetermineBasalAdapterTsunamiJS internal constructor(private val scriptRead
         this.profile.put("insulinID", insulinID)
         this.profile.put("tsuSMBCap", SafeParse.stringToDouble(sp.getString(R.string.key_tsunami_smbcap, "1")))
         this.profile.put("tsuInsReqPCT", SafeParse.stringToDouble(sp.getString(R.string.key_insulinReqPCT, "65")))
-        this.profile.put("percentage", profile.percentage)
+        this.profile.put("percentage", profile.getOriginalPercentage())
         this.profile.put("dia", profile.dia)
         this.profile.put("tsunamiActive", tsunamiActive)
         this.profile.put("enableWaveMode", sp.getBoolean(R.string.key_enable_wave_mode, false))


### PR DESCRIPTION
This fixes the profile percentage multiplier

Disclaimer: I have not fully tested this in the new Tsunami context, however running it for some time on my own fork. And I did a quick test on my dev phone with tsunami + this fix, and the percentage shows up correctly in the TSU tab